### PR TITLE
add execution id to the name to handle multiple plugin executions

### DIFF
--- a/src/main/java/co/leantechniques/maven/buildtime/MojoExecutionName.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/MojoExecutionName.java
@@ -3,15 +3,17 @@ package co.leantechniques.maven.buildtime;
 import org.apache.maven.plugin.MojoExecution;
 
 public class MojoExecutionName {
+    private final String id;
     private final String artifactId;
     private final String goal;
 
     public MojoExecutionName(MojoExecution mojoExecution) {
+        this.id = mojoExecution.getExecutionId();
         this.artifactId = mojoExecution.getArtifactId();
         this.goal = mojoExecution.getGoal();
     }
 
     public String getName() {
-        return String.format("%s:%s", artifactId, goal);
+        return String.format("%s:%s (%s)", artifactId, goal, id);
     }
 }

--- a/src/main/java/co/leantechniques/maven/buildtime/MojoTimer.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/MojoTimer.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 
 public class MojoTimer {
 
+    public static final int MAX_NAME_LENGTH = 58;
     private String name;
     private long startTime = 0;
     private long endTime = 0;
@@ -43,10 +44,11 @@ public class MojoTimer {
 
     public void write(Logger logger) {
         // 68 char width: coefficient-core .................................. SUCCESS [0.846s]
-        logger.info(String.format("  %s %s [%.3fs]", getName(), StringUtils.repeat(".", calculateLineLength()), (double)getDuration()/1000));
+        logger.info(String.format("  %s [%.3fs]", getDisplayName(), (double)getDuration()/1000));
     }
 
-    private int calculateLineLength() {
-        return 57 - name.length();
+    private String getDisplayName() {
+        String truncatedName = name.length() >= MAX_NAME_LENGTH ? StringUtils.substring(name, 0, MAX_NAME_LENGTH) : name + " ";
+        return StringUtils.rightPad(truncatedName, MAX_NAME_LENGTH, ".");
     }
 }

--- a/src/test/java/co/leantechniques/maven/buildtime/MojoExecutionNameTest.java
+++ b/src/test/java/co/leantechniques/maven/buildtime/MojoExecutionNameTest.java
@@ -1,0 +1,21 @@
+package co.leantechniques.maven.buildtime;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecution;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MojoExecutionNameTest {
+
+    @Test
+    public void getName() throws Exception {
+        Plugin plugin = new Plugin();
+        plugin.setArtifactId("artifact");
+        MojoExecution execution = new MojoExecution(plugin, "goal", "id");
+
+        MojoExecutionName executionName = new MojoExecutionName(execution);
+
+        assertEquals("artifact:goal (id)", executionName.getName());
+    }
+}

--- a/src/test/java/co/leantechniques/maven/buildtime/MojoTimerTest.java
+++ b/src/test/java/co/leantechniques/maven/buildtime/MojoTimerTest.java
@@ -33,4 +33,16 @@ public class MojoTimerTest {
         new MojoTimer("Some really long project name", 0,100100).write(logger);
         verify(logger).info("  Some really long project name ............................ [100.100s]");
     }
+
+    @Test
+    public void outputWithNameAtTheMaxLength() {
+        new MojoTimer("Some really,  really,  really,  really,  long project name", 0,100100).write(logger);
+        verify(logger).info("  Some really,  really,  really,  really,  long project name [100.100s]");
+    }
+
+    @Test
+    public void outputWithNameOverTheMaxLength() {
+        new MojoTimer("Some really,  really,  really,  really,  really,  long project name", 0,100100).write(logger);
+        verify(logger).info("  Some really,  really,  really,  really,  really,  long pro [100.100s]");
+    }
 }


### PR DESCRIPTION
When multiple executions of the same plugin were being performed in the same project it was only displaying the duration for the last execution. This adds the execution id to the name to make it unique.

An example of this is using surefire to run both unit and integration tests in different phases. Only the integration run would be recorded.

Also, I'm not sure if the 68 character limit was an arbitrary number, but the likelihood of names being cutoff is greater now. 

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.001 s
[INFO] Finished at: 2014-06-12T16:02:08-06:00
[INFO] Final Memory: 11M/62M
[INFO] ------------------------------------------------------------------------
[INFO] Build Time Summary:
[INFO]
[INFO] maven-buildtime-extension
[INFO]   maven-clean-plugin:clean (default-clean) ................. [0.043s]
[INFO]   maven-enforcer-plugin:enforce (enforce-maven) ............ [0.102s]
[INFO]   maven-resources-plugin:resources (default-resources) ..... [0.073s]
[INFO]   maven-compiler-plugin:compile (default-compile) .......... [0.280s]
[INFO]   plexus-component-metadata:generate-metadata (default) .... [0.149s]
[INFO]   maven-resources-plugin:testResources (default-testResource [0.003s]
[INFO]   maven-compiler-plugin:testCompile (default-testCompile) .. [0.067s]
[INFO]   plexus-component-metadata:generate-test-metadata (default) [0.009s]
[INFO]   maven-surefire-plugin:test (default-test) ................ [0.690s]
[INFO]   maven-jar-plugin:jar (default-jar) ....................... [0.216s]
[INFO] ------------------------------------------------------------------------
```
