### PR TITLE
Implement #8: configurable logging to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ displays the duration for each goal that is ran during your build.
 
 # Usage
 Put this in your pom.xml to find out why you are slow.
+By default this will log only to maven debug `-X,--debug`, however debug is quite noisy so you can enable output to normal log
+via the property `buildtime.output.log` in your pom or via commandline `-Dbuildtime.output.log=true`.
 
 ## Capture the results to a CSV file
-Thanks to [@leonard84](https://github.com/leonard84) for the contribution. You'll need to set a property to enable this feature. Eventually, we can enhance this funcationality to include other output formats. I personally would like to publish the results to an InfluxDb instance.
+Thanks to [@leonard84](https://github.com/leonard84) for the contribution. You'll need to set a property to enable this feature. Eventually, we can enhance this functionality to include other output formats. I personally would like to publish the results to an InfluxDb instance.
 
 ```
 mvn compile -Dbuildtime.output.csv=true -Dbuildtime.output.csv.file=classes\out.csv

--- a/src/main/java/co/leantechniques/maven/buildtime/LogOutput.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/LogOutput.java
@@ -1,0 +1,22 @@
+package co.leantechniques.maven.buildtime;
+
+import org.slf4j.Logger;
+
+public class LogOutput {
+
+    private Logger logger;
+    private boolean logToInfo;
+
+    public LogOutput(Logger logger, boolean logToInfo) {
+        this.logger = logger;
+        this.logToInfo = logToInfo;
+    }
+
+    public void log(String string) {
+        if (logToInfo) {
+            logger.info(string);
+        } else {
+            logger.debug(string);
+        }
+    }
+}

--- a/src/main/java/co/leantechniques/maven/buildtime/MojoTimer.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/MojoTimer.java
@@ -4,7 +4,6 @@ import java.io.PrintWriter;
 import java.util.Locale;
 
 import org.codehaus.plexus.util.StringUtils;
-import org.slf4j.Logger;
 
 public class MojoTimer {
 
@@ -45,9 +44,9 @@ public class MojoTimer {
         this.startTime = systemClock.currentTimeMillis();
     }
 
-    public void write(Logger logger) {
+    public void write(LogOutput logOutput) {
         // 68 char width: coefficient-core .................................. SUCCESS [0.846s]
-        logger.info(String.format(Locale.ENGLISH, "  %s [%.3fs]", getDisplayName(), (double)getDuration()/1000));
+        logOutput.log(String.format(Locale.ENGLISH, "  %s [%.3fs]", getDisplayName(), (double)getDuration()/1000));
     }
 
     private String getDisplayName() {

--- a/src/main/java/co/leantechniques/maven/buildtime/ProjectTimer.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/ProjectTimer.java
@@ -4,8 +4,6 @@ import java.io.PrintWriter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.slf4j.Logger;
-
 public class ProjectTimer {
 
     private Map<String, MojoTimer> dataStore = new ConcurrentHashMap<String, MojoTimer>();
@@ -20,9 +18,9 @@ public class ProjectTimer {
         this(new ConcurrentHashMap<String, MojoTimer>(), systemClock);
     }
 
-    public void write(Logger logger) {
+    public void write(LogOutput logOutput) {
         for (MojoTimer mojo : dataStore.values()){
-            mojo.write(logger);
+            mojo.write(logOutput);
         }
     }
 

--- a/src/main/java/co/leantechniques/maven/buildtime/SessionTimer.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/SessionTimer.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
-import org.slf4j.Logger;
 
 public class SessionTimer {
 
@@ -32,16 +31,16 @@ public class SessionTimer {
         return projects.get(projectArtifactId);
     }
 
-    public void write(Logger logger) {
+    public void write(LogOutput logOutput) {
 
-        logger.info("Build Time Summary:");
-        logger.info("");
+        logOutput.log("Build Time Summary:");
+        logOutput.log("");
         for(String projectName : projects.keySet()) {
-            logger.info(String.format("%s", projectName));
+            logOutput.log(String.format("%s", projectName));
             ProjectTimer projectTimer = projects.get(projectName);
-            projectTimer.write(logger);
+            projectTimer.write(logOutput);
         }
-        logger.info(DIVIDER);
+        logOutput.log(DIVIDER);
     }
 
     public void mojoStarted(MavenProject project, MojoExecution mojoExecution) {

--- a/src/main/java/org/apache/maven/cli/ExecutionTimingExecutionListener.java
+++ b/src/main/java/org/apache/maven/cli/ExecutionTimingExecutionListener.java
@@ -10,6 +10,7 @@ import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
 import org.slf4j.Logger;
 
+import co.leantechniques.maven.buildtime.LogOutput;
 import co.leantechniques.maven.buildtime.SessionTimer;
 
 public class ExecutionTimingExecutionListener extends ExecutionEventLogger {
@@ -17,6 +18,7 @@ public class ExecutionTimingExecutionListener extends ExecutionEventLogger {
     public static final String BUILDTIME_OUTPUT_CSV_FILE_PROPERTY = "buildtime.output.csv.file";
     public static final String BUILDTIME_OUTPUT_CSV_FILE = "buildtime.csv";
     public static final String BUILDTIME_OUTPUT_CSV_PROPERTY = "buildtime.output.csv";
+    public static final String BUILDTIME_OUTPUT_LOG = "buildtime.output.log";
 
     private final Logger logger;
     private final SessionTimer session = new SessionTimer();
@@ -47,7 +49,8 @@ public class ExecutionTimingExecutionListener extends ExecutionEventLogger {
     @Override
     public void sessionEnded(final ExecutionEvent event) {
         super.sessionEnded(event);
-        session.write(logger);
+        LogOutput logOutput = new LogOutput(logger, Boolean.parseBoolean(getExecutionProperty(event, BUILDTIME_OUTPUT_LOG, "false")));
+        session.write(logOutput);
         csvOutput(event);
 
     }

--- a/src/test/java/co/leantechniques/maven/buildtime/MojoTimerTest.java
+++ b/src/test/java/co/leantechniques/maven/buildtime/MojoTimerTest.java
@@ -2,6 +2,7 @@ package co.leantechniques.maven.buildtime;
 
 import static org.mockito.Mockito.verify;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -13,9 +14,16 @@ public class MojoTimerTest {
     @Mock
     private Logger logger;
 
+    private LogOutput logOutput;
+
+    @Before
+    public void setUp() {
+        logOutput = new LogOutput(logger, true);
+    }
+
     @Test
     public void outputWithSubsecond() {
-        new MojoTimer("1234567890", 100,200).write(logger);
+        new MojoTimer("1234567890", 100,200).write(logOutput);
 
                     //coefficient-core .................................. SUCCESS [0.846s]
                     //coefficient-core .................................. SUCCESS [100.846s]
@@ -24,25 +32,33 @@ public class MojoTimerTest {
 
     @Test
     public void outputWith100Seconds() {
-        new MojoTimer("1234567890", 0,100100).write(logger);
+        new MojoTimer("1234567890", 0,100100).write(logOutput);
         verify(logger).info("  1234567890 ............................................... [100.100s]");
     }
 
     @Test
     public void outputWithLongPluginName() {
-        new MojoTimer("Some really long project name", 0,100100).write(logger);
+        new MojoTimer("Some really long project name", 0,100100).write(logOutput);
         verify(logger).info("  Some really long project name ............................ [100.100s]");
+    }
+
+
+    @Test
+    public void outputToDebug() {
+        logOutput = new LogOutput(logger, false);
+        new MojoTimer("Some really long project name", 0,100100).write(logOutput);
+        verify(logger).debug("  Some really long project name ............................ [100.100s]");
     }
 
     @Test
     public void outputWithNameAtTheMaxLength() {
-        new MojoTimer("Some really,  really,  really,  really,  long project name", 0,100100).write(logger);
+        new MojoTimer("Some really,  really,  really,  really,  long project name", 0,100100).write(logOutput);
         verify(logger).info("  Some really,  really,  really,  really,  long project name [100.100s]");
     }
 
     @Test
     public void outputWithNameOverTheMaxLength() {
-        new MojoTimer("Some really,  really,  really,  really,  really,  long project name", 0,100100).write(logger);
+        new MojoTimer("Some really,  really,  really,  really,  really,  long project name", 0,100100).write(logOutput);
         verify(logger).info("  Some really,  really,  really,  really,  really,  long pro [100.100s]");
     }
 }

--- a/src/test/java/co/leantechniques/maven/buildtime/SessionTimerTest.java
+++ b/src/test/java/co/leantechniques/maven/buildtime/SessionTimerTest.java
@@ -32,6 +32,8 @@ public class SessionTimerTest {
     private LinkedHashMap<String, MojoTimer> mojoTiming;
     @Mock
     private Logger logger;
+
+    private LogOutput logOutput;
     private MojoExecution mojoExecution;
     private MavenProject project;
     private PrintWriter printWriter;
@@ -40,6 +42,7 @@ public class SessionTimerTest {
 
     @Before
     public void setUp() throws Exception {
+        logOutput = new LogOutput(logger, true);
         existingProjects = new HashMap<String, ProjectTimer>();
         SystemClock mockClock = mock(SystemClock.class);
         when(mockClock.currentTimeMillis())
@@ -81,7 +84,7 @@ public class SessionTimerTest {
 
         existingProjects.put("one", oneProject);
 
-        sessionTimer.write(logger);
+        sessionTimer.write(logOutput);
 
         String dividerLine = SessionTimer.DIVIDER;
         verify(logger).info("Build Time Summary:");


### PR DESCRIPTION
This implementation supports both modes of operation mentioned in #8, by default it logs to debug but this can be changed to info-level via property.