### PR TITLE
Output execution times in the order of executions

### DIFF
--- a/src/main/java/co/leantechniques/maven/buildtime/MojoTimer.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/MojoTimer.java
@@ -1,6 +1,8 @@
 package co.leantechniques.maven.buildtime;
 
-public class MojoTimer {
+import java.lang.Comparable;
+
+public class MojoTimer implements Comparable<MojoTimer> {
 
     private final String projectName;
 
@@ -47,5 +49,20 @@ public class MojoTimer {
 
     public void accept(TimerVisitor visitor){
         visitor.visit(this);
+    }
+
+    public int compareTo(MojoTimer that) {
+        if (that == null)
+            return 1;
+
+        if (this == that)
+            return 0;
+
+        if (this.startTime > that.startTime)
+            return 1;
+        else if (this.startTime < that.startTime)
+            return -1;
+
+        return 0;
     }
 }

--- a/src/main/java/co/leantechniques/maven/buildtime/SessionTimer.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/SessionTimer.java
@@ -1,20 +1,20 @@
 package co.leantechniques.maven.buildtime;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
 public class SessionTimer {
-    private Map<String, ProjectTimer> projects;
+    private ConcurrentMap<String, ProjectTimer> projects;
     private SystemClock systemClock;
 
     public SessionTimer() {
         this(new ConcurrentHashMap<String, ProjectTimer>(), new SystemClock());
     }
 
-    public SessionTimer(Map<String, ProjectTimer> projects, SystemClock systemClock) {
+    public SessionTimer(ConcurrentMap<String, ProjectTimer> projects, SystemClock systemClock) {
         this.projects = projects;
         this.systemClock = systemClock;
     }
@@ -24,7 +24,9 @@ public class SessionTimer {
     }
 
     public ProjectTimer getProject(String projectArtifactId) {
-        if(!projects.containsKey(projectArtifactId)) projects.put(projectArtifactId, new ProjectTimer(projectArtifactId, systemClock));
+        if (!projects.containsKey(projectArtifactId)) 
+            projects.putIfAbsent(projectArtifactId, new ProjectTimer(projectArtifactId, systemClock));
+
         return projects.get(projectArtifactId);
     }
 


### PR DESCRIPTION
Right now when I run the build all execution times are printed in random order, since `ConcurrentHashMap` doesn't preserve insertion order. This seems wrong to me as I was expecting to see results in order of execution. 

This PR sorts instances of `MojoTimer` by `startTime` before logging and that seems to be good enough. 

Let me know what you think.