### PR TITLE
Added Start and End Times (as epoch millis) to CSV output

### DIFF
--- a/src/main/java/co/leantechniques/maven/buildtime/output/CsvReporter.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/output/CsvReporter.java
@@ -52,7 +52,7 @@ public class CsvReporter implements Reporter {
     }
 
     public void writeTo(SessionTimer session, PrintWriter printWriter) {
-        printWriter.println("\"Module\";\"Mojo\";\"Time\"");
+        printWriter.println("\"Module\";\"Mojo\";\"Time\";\"Start\";\"End\"");
         session.accept(new CsvReportVisitor(printWriter));
     }
 
@@ -65,8 +65,8 @@ public class CsvReporter implements Reporter {
 
         @Override
         public void visit(MojoTimer mojoTimer) {
-            printWriter.format(Locale.ENGLISH, "\"%s\";\"%s\";\"%.3f\"%n",
-                    mojoTimer.getProjectName(), mojoTimer.getName(), mojoTimer.getDuration() / 1000d);
+            printWriter.format(Locale.ENGLISH, "\"%s\";\"%s\";\"%.3f\";\"%d\";\"%d\"%n",
+                    mojoTimer.getProjectName(), mojoTimer.getName(), mojoTimer.getDuration() / 1000d, mojoTimer.getStartTime(), mojoTimer.getEndTime());
         }
     }
 }

--- a/src/main/java/co/leantechniques/maven/buildtime/output/LogReporter.java
+++ b/src/main/java/co/leantechniques/maven/buildtime/output/LogReporter.java
@@ -44,7 +44,7 @@ public class LogReporter implements Reporter {
 
         @Override
         public void visit(ProjectTimer projectTimer) {
-            logOutput.log(String.format("%s [%.3fs]", projectTimer.getProjectName(), projectTimer.getDuration() / 1000d));
+            logOutput.log(String.format(Locale.ENGLISH, "%s [%.3fs]", projectTimer.getProjectName(), projectTimer.getDuration() / 1000d));
         }
 
         @Override

--- a/src/test/java/co/leantechniques/maven/buildtime/SessionTimerTest.java
+++ b/src/test/java/co/leantechniques/maven/buildtime/SessionTimerTest.java
@@ -33,6 +33,8 @@ import co.leantechniques.maven.buildtime.output.LogReporter;
 @RunWith(MockitoJUnitRunner.class)
 public class SessionTimerTest {
 
+    private static final String CSV_HEADERS = "\"Module\";\"Mojo\";\"Time\";\"Start\";\"End\"";
+
     private ConcurrentMap<String,ProjectTimer> existingProjects;
     private SessionTimer sessionTimer;
     private ProjectTimer oneProject;
@@ -163,9 +165,9 @@ public class SessionTimerTest {
         String output = outputStream.toString();
         String[] split = output.split("\r?\n");
 
-        Assert.assertEquals(split[0], "\"Module\";\"Mojo\";\"Time\"");
-        Assert.assertEquals(split[1], "\"one\";\"artifactId:goal1\";\"0.001\"");
-        Assert.assertEquals(split[2], "\"one\";\"artifactId:goal2\";\"0.002\"");
+        Assert.assertEquals(split[0], CSV_HEADERS);
+        Assert.assertEquals(split[1], "\"one\";\"artifactId:goal1\";\"0.001\";\"1\";\"2\"");
+        Assert.assertEquals(split[2], "\"one\";\"artifactId:goal2\";\"0.002\";\"2\";\"4\"");
         Assert.assertEquals(split.length, 3);
     }
 
@@ -191,11 +193,11 @@ public class SessionTimerTest {
         String output = outputStream.toString();
         String[] split = output.split("\r?\n");
 
-        Assert.assertEquals(split[0], "\"Module\";\"Mojo\";\"Time\"");
-        Assert.assertEquals(split[1], "\"two\";\"artifactId:goal3\";\"0.001\"");
-        Assert.assertEquals(split[2], "\"two\";\"artifactId:goal4\";\"0.002\"");
-        Assert.assertEquals(split[3], "\"one\";\"artifactId:goal2\";\"0.002\"");
-        Assert.assertEquals(split[4], "\"one\";\"artifactId:goal1\";\"0.003\"");
+        Assert.assertEquals(split[0], CSV_HEADERS);
+        Assert.assertEquals(split[1], "\"two\";\"artifactId:goal3\";\"0.001\";\"1\";\"2\"");
+        Assert.assertEquals(split[2], "\"two\";\"artifactId:goal4\";\"0.002\";\"2\";\"4\"");
+        Assert.assertEquals(split[3], "\"one\";\"artifactId:goal2\";\"0.002\";\"5\";\"7\"");
+        Assert.assertEquals(split[4], "\"one\";\"artifactId:goal1\";\"0.003\";\"6\";\"9\"");
         Assert.assertEquals(split.length, 5);
     }
 

--- a/src/test/java/co/leantechniques/maven/buildtime/SessionTimerTest.java
+++ b/src/test/java/co/leantechniques/maven/buildtime/SessionTimerTest.java
@@ -166,6 +166,7 @@ public class SessionTimerTest {
         Assert.assertEquals(split[0], "\"Module\";\"Mojo\";\"Time\"");
         Assert.assertEquals(split[1], "\"one\";\"artifactId:goal1\";\"0.001\"");
         Assert.assertEquals(split[2], "\"one\";\"artifactId:goal2\";\"0.002\"");
+        Assert.assertEquals(split.length, 3);
     }
 
     @Test
@@ -195,6 +196,7 @@ public class SessionTimerTest {
         Assert.assertEquals(split[2], "\"two\";\"artifactId:goal4\";\"0.002\"");
         Assert.assertEquals(split[3], "\"one\";\"artifactId:goal2\";\"0.002\"");
         Assert.assertEquals(split[4], "\"one\";\"artifactId:goal1\";\"0.003\"");
+        Assert.assertEquals(split.length, 5);
     }
 
     @Test

--- a/src/test/java/org/apache/maven/cli/BuildTimeEventSpyTest.java
+++ b/src/test/java/org/apache/maven/cli/BuildTimeEventSpyTest.java
@@ -33,6 +33,8 @@ import co.leantechniques.maven.buildtime.output.LogReporter;
 @RunWith(MockitoJUnitRunner.class)
 public class BuildTimeEventSpyTest {
 
+    private static final String CSV_HEADERS = "\"Module\";\"Mojo\";\"Time\";\"Start\";\"End\"";
+
     @Mock
     private Logger logger;
 
@@ -75,7 +77,7 @@ public class BuildTimeEventSpyTest {
 
         assertTrue(testFile.exists());
         List<String> lines = FileUtils.loadFile(testFile);
-        assertEquals("\"Module\";\"Mojo\";\"Time\"", lines.get(0));
+        assertEquals(CSV_HEADERS, lines.get(0));
     }
 
 
@@ -93,14 +95,16 @@ public class BuildTimeEventSpyTest {
 
         assertTrue(testFile.exists());
         List<String> lines = FileUtils.loadFile(testFile);
-        assertEquals("\"Module\";\"Mojo\";\"Time\"", lines.get(0));
+        assertEquals(CSV_HEADERS, lines.get(0));
 
         String[] split = lines.get(1).split(";");
 
-        assertEquals(3, split.length);
+        assertEquals(5, split.length);
         assertEquals("\"maven-project-artifact\"", split[0]);
         assertEquals("\"plugin:goal (executionId)\"", split[1]);
         assertTrue(Pattern.matches("\"\\d+\\.\\d+\"", split[2]));
+        assertTrue(Pattern.matches("\"\\d+\"", split[3]));
+        assertTrue(Pattern.matches("\"\\d+\"", split[4]));
 
     }
 


### PR DESCRIPTION
Hello, in Order to get Information where my multi-module build is losing time due to not all workers being utilized, i need not only the duration that different mojos (or actually the modules as a whole) take to execute but also the start and end times. 